### PR TITLE
New split options + bugfix

### DIFF
--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -1,7 +1,7 @@
 // Planned new split options to implement:
 //		1. Split on the Comms Relay cutscene (useful for Text Storage No OoB) - DONE
 //		2. Disable splitting on trinkets when in time trial (useful for All Achievements) - DONE
-//		3. Only split on time trials when V Rank achieved (useful for All Achievements)
+//		3. Only split on time trials when V Rank achieved (useful for All Achievements) - IN PROGRESS
 
 state("VVVVVV", "unknown") {
 	// Default state
@@ -221,8 +221,11 @@ startup {
 	vars.labTelejump = "Split on teleporting to the teleporter under Lab";
 	vars.towerTelejump = "Split on teleporting to the teleporter under Tower";
 
+	vars.allAchievementsParent = "Settings pertaining to All Achievements";
+	vars.disableTimeTrialTrinkets = "Disable splitting on trinkets when in a time trial (v2.4.1+ currently)";
+	vars.requireVRank = "Only split on completing time trials when V Rank is achieved (v2.4.4+ currently)";
+
 	vars.trinkets = "Split on collecting trinkets";
-	vars.disableTimeTrialTrinkets = "Disable splitting on trinkets when in a time trial (for All Achievements) (v2.4.1+ currently)";
 	vars.trinketSecretToNobody = "Split on collecting the \"It's a Secret to Nobody\" trinket";
 	vars.trinketTrenchWarfare = "Split on collecting the \"Trench Warfare\" trinket";
 	vars.trinketWorthTheChallenge = "Split on collecting the \"Young Man, It's Worth the Challenge\" trinket";
@@ -278,7 +281,6 @@ startup {
 	settings.CurrentDefaultParent = vars.hundredpercentParent;
 	settings.Add(vars.trinkets, false);
 	settings.CurrentDefaultParent = vars.trinkets;
-	settings.Add(vars.disableTimeTrialTrinkets, false);
 	settings.Add(vars.trinketSecretToNobody, false);
 	settings.Add(vars.trinketTrenchWarfare, false);
 	settings.Add(vars.trinketWorthTheChallenge, false);
@@ -299,6 +301,11 @@ startup {
 	settings.Add(vars.trinketCave3, false);
 	settings.Add(vars.trinketEdgeGames, false);
 	settings.Add(vars.trinketV, false);
+
+	settings.CurrentDefaultParent = vars.hundredpercentParent;
+	settings.Add(vars.allAchievementsParent, false);
+	settings.CurrentDefaultParent = vars.allAchievementsParent;
+	settings.Add(vars.disableTimeTrialTrinkets, false);
 
 	settings.CurrentDefaultParent = vars.hundredpercentParent;
 	settings.Add(vars.labTelejump, false);

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -4,39 +4,39 @@ state("VVVVVV", "unknown") {
 
 state("VVVVVV", "v2.4.4") {
 	// Game time variables
-	int gametimeFrames : "VVVVVV.exe", 0x410BA0;
-	int gametimeSeconds : "VVVVVV.exe", 0x410BA4;
-	int gametimeMinutes : "VVVVVV.exe", 0x410BA8;
-	int gametimeHours : "VVVVVV.exe", 0x410BAC;
+	int gametimeFrames : "VVVVVV.exe", 0x410BA0; // game.frames
+	int gametimeSeconds : "VVVVVV.exe", 0x410BA4; // game.seconds
+	int gametimeMinutes : "VVVVVV.exe", 0x410BA8; // game.minutes
+	int gametimeHours : "VVVVVV.exe", 0x410BAC; // game.hours
 
 	// Variables for starting the timer
-	bool fadetomode : "VVVVVV.exe", 0x225A34;
-	int gotomode : "VVVVVV.exe", 0x225A38;
-	int timetrialcountdown : "VVVVVV.exe", 0x410D18;
+	bool fadetomode : "VVVVVV.exe", 0x225A34; // see README at https://github.com/KSSBrawl/vvvvvv-ida-includes
+	int gotomode : "VVVVVV.exe", 0x225A38; // see above
+	int timetrialcountdown : "VVVVVV.exe", 0x410D18; // game.timetrialcountdown
 
 	// Variables for stopping the timer on Game Complete
-	int saveFrames : "VVVVVV.exe", 0x410BD0;
-	int saveSeconds : "VVVVVV.exe", 0x410BD4;
+	int saveFrames : "VVVVVV.exe", 0x410BD0; // game.saveframes
+	int saveSeconds : "VVVVVV.exe", 0x410BD4; // game.saveseconds
 
 	// Variables for splitting
-	bool finalStretch : "VVVVVV.exe", 0x4136C9;
-	int gamestate : "VVVVVV.exe", 0x410B50; // actually called state in source
-	string255 firstTextLineSmall : "VVVVVV.exe", 0x233980, 0x0;
-	string255 firstTextLineLarge : "VVVVVV.exe", 0x233980, 0x0, 0x0;
-	int teleport_to_x : "VVVVVV.exe", 0x410C00;
-	int teleport_to_y : "VVVVVV.exe", 0x410C04;
-	byte100 collect : "VVVVVV.exe", 0x221790;
+	bool finalStretch : "VVVVVV.exe", 0x4136C9; // map.finalstretch
+	int gamestate : "VVVVVV.exe", 0x410B50; // game.state
+	string255 firstTextLineSmall : "VVVVVV.exe", 0x233980, 0x0; // script.txt (script = scriptclass)
+	string255 firstTextLineLarge : "VVVVVV.exe", 0x233980, 0x0, 0x0; // script.text
+	int teleport_to_x : "VVVVVV.exe", 0x410C00; // game.teleport_to_x
+	int teleport_to_y : "VVVVVV.exe", 0x410C04; // game.teleport_to_y
+	byte100 collect : "VVVVVV.exe", 0x221790; // obj.collect (obj = entityclass)
 
 	// Time trial variables for calculating V rank
 	// Why not just read the timetrialrank variable? In short, because of race conditions.
 	// We can't reliably read from any variables which are affected by gamestate 82 while also listening out for gamestate 82.
-	int deathCount : "VVVVVV.exe", 0x410B94;
-	int timeTrialShinyTarget : "VVVVVV.exe", 0x410D1C;
-	int timeTrialPar : "VVVVVV.exe", 0x410D24;
+	int deathCount : "VVVVVV.exe", 0x410B94; // game.deathcount
+	int timeTrialShinyTarget : "VVVVVV.exe", 0x410D1C; // game.timetrialshinytarget
+	int timeTrialPar : "VVVVVV.exe", 0x410D24; // game.timetrialpar
 
 	// Variables for resetting
-	int menustate : "VVVVVV.exe", 0x410B5C; // actually called gamestate in source
-	bool ingame_titlemode : "VVVVVV.exe", 0x411566;
+	int menustate : "VVVVVV.exe", 0x410B5C; // game.gamestate
+	bool ingame_titlemode : "VVVVVV.exe", 0x411566; // game.ingame_titlemode
 }
 
 state("VVVVVV", "v2.4.3") {

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -14,6 +14,10 @@ state("VVVVVV", "v2.4.4") {
 	int gotomode : "VVVVVV.exe", 0x225A38;
 	int timetrialcountdown : "VVVVVV.exe", 0x410D18;
 
+	// Variables for stopping the timer on Game Complete
+	int saveFrames : "VVVVVV.exe", 0x410BD0;
+	int saveSeconds : "VVVVVV.exe", 0x410BD4;
+
 	// Variables for splitting
 	bool finalStretch : "VVVVVV.exe", 0x4136C9;
 	int gamestate : "VVVVVV.exe", 0x410B50; // actually called state in source
@@ -455,6 +459,7 @@ start {
 		// Triggers when fade to new mode completes
 		if (!current.fadetomode && old.fadetomode) {
 			vars.isInTimeTrial = false;
+			vars.isGameComplete = false;
 
 			if (current.gotomode == 0) {
 				// New game
@@ -530,6 +535,13 @@ start {
 
 split {
 	if (version == "v2.4.1" || version == "v2.4.2" || version == "v2.4.3" || version == "v2.4.4") {
+		// In order to fix the bug where the timer often stopped a frame late, I forced the autosplitter to wait an extra cycle before actually stopping
+		// the timer. This is so that the gameTime method can be run one more time before the timer stops, in which it will switch over to displaying
+		// the save file's saved time (set in gamestate 3502) instead of the in-game time.
+		if (vars.isGameComplete) {
+			return true;
+		}
+
 		// Trinket splits
 		if (settings[vars.trinkets]) {
 			if (!settings[vars.disableTimeTrialTrinkets] || settings[vars.disableTimeTrialTrinkets] && !vars.isInTimeTrial) {
@@ -662,7 +674,7 @@ split {
 					}
 
 					if (allTrinketsKludge) {
-						return settings[vars.gameComplete];
+						vars.isGameComplete = settings[vars.gameComplete];
 					}
 				}
 			} else if (current.gamestate == 33) {
@@ -962,7 +974,13 @@ reset {
 }
 
 gameTime {
-	if (version == "v2.3.4" || version == "v2.3.6" || version == "v2.4" || version == "v2.4.1" || version == "v2.4.2" || version == "v2.4.3" || version == "v2.4.4") {
+	if (version == "v2.4.4") { // we separate out v2.4.4 because it's the only version so far in which saveSeconds and saveFrames are stored to the state
+		if (vars.isGameComplete) { // evil hack to get the timer to show the right time on game complete (after gamestate 3503)
+			return new TimeSpan(0, current.saveSeconds / 3600, current.saveSeconds % 3600 / 60, current.saveSeconds % 60, 100 * current.saveFrames / 3);
+		} else {
+			return new TimeSpan(0, current.gametimeHours, current.gametimeMinutes, current.gametimeSeconds, 100*current.gametimeFrames/3);
+		}
+	} else if (version == "v2.3.4" || version == "v2.3.6" || version == "v2.4" || version == "v2.4.1" || version == "v2.4.2" || version == "v2.4.3") {
 		return new TimeSpan(0, current.gametimeHours, current.gametimeMinutes, current.gametimeSeconds, 100*current.gametimeFrames/3);
 	} else if (version == "v2.0" || version == "v2.2") {
 		// Legacy versions

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -249,6 +249,7 @@ startup {
 	vars.dis = "Split on talking to Victoria (for DIS)";
 	vars.finalStretch = "Split on Final Level terminal";
 	vars.hello = "Split on \"Hello!\" (for Text Storage and Credits Warp)";
+	vars.commsRelay = "Split on activating the cutscene in Comms Relay";
 
 	settings.Add(vars.startresetParent, true);
 	settings.CurrentDefaultParent = vars.startresetParent;
@@ -309,6 +310,7 @@ startup {
 	settings.Add(vars.dis, false);
 	settings.Add(vars.finalStretch, false);
 	settings.Add(vars.hello, false);
+	settings.Add(vars.commsRelay, false);
 }
 
 init {
@@ -669,6 +671,11 @@ split {
 			} else if (current.gamestate == 4020 && current.teleport_to_x == 0 && current.teleport_to_y == 0) {
 				// Split on teleporting to the teleporter under Lab
 				return settings[vars.labTelejump];
+			} else if (current.gamastate == 31) {
+				if (old.gamestate != 31) {
+					// Split on activating the cutscene in Comms Relay
+					return settings[vars.commsRelay];
+				}
 			}
 		}
 		

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -1,6 +1,6 @@
 // Planned new split options to implement:
 //		1. Split on the Comms Relay cutscene (useful for Text Storage No OoB) - DONE
-//		2. Disable splitting on trinkets when in time trial (useful for All Achievements)
+//		2. Disable splitting on trinkets when in time trial (useful for All Achievements) - TESTING
 //		3. Only split on time trials when V Rank achieved (useful for All Achievements)
 
 state("VVVVVV", "unknown") {
@@ -222,6 +222,7 @@ startup {
 	vars.towerTelejump = "Split on teleporting to the teleporter under Tower";
 
 	vars.trinkets = "Split on collecting trinkets";
+	vars.disableTimeTrialTrinkets = "Disable splitting on trinkets when in a time trial (for All Achievements) (v2.4.1+ currently)";
 	vars.trinketSecretToNobody = "Split on collecting the \"It's a Secret to Nobody\" trinket";
 	vars.trinketTrenchWarfare = "Split on collecting the \"Trench Warfare\" trinket";
 	vars.trinketWorthTheChallenge = "Split on collecting the \"Young Man, It's Worth the Challenge\" trinket";
@@ -249,7 +250,7 @@ startup {
 	vars.dis = "Split on talking to Victoria (for DIS)";
 	vars.finalStretch = "Split on Final Level terminal";
 	vars.hello = "Split on \"Hello!\" (for Text Storage and Credits Warp)";
-	vars.commsRelay = "Split on activating the cutscene in Comms Relay";
+	vars.commsRelay = "Split on activating the cutscene in Comms Relay (v2.4.1+ currently)";
 
 	settings.Add(vars.startresetParent, true);
 	settings.CurrentDefaultParent = vars.startresetParent;
@@ -277,6 +278,7 @@ startup {
 	settings.CurrentDefaultParent = vars.hundredpercentParent;
 	settings.Add(vars.trinkets, false);
 	settings.CurrentDefaultParent = vars.trinkets;
+	settings.Add(vars.disableTimeTrialTrinkets, false);
 	settings.Add(vars.trinketSecretToNobody, false);
 	settings.Add(vars.trinketTrenchWarfare, false);
 	settings.Add(vars.trinketWorthTheChallenge, false);
@@ -442,6 +444,8 @@ start {
 	if (version == "v2.3.4" || version == "v2.3.6" || version == "v2.4" || version == "v2.4.1" || version == "v2.4.2" || version == "v2.4.3" || version == "v2.4.4") {
 		// Triggers when fade to new mode completes
 		if (!current.fadetomode && old.fadetomode) {
+			vars.isInTimeTrial = false;
+
 			if (current.gotomode == 0) {
 				// New game
 				return settings[vars.newgame];
@@ -485,6 +489,7 @@ start {
 		if (current.timetrialcountdown != old.timetrialcountdown) {
 			if (current.timetrialcountdown <= 30 && old.timetrialcountdown > 30) {
 				// Start when time trial countdown ends
+				vars.isInTimeTrial = true;
 				return settings[vars.ils];
 			}
 		}
@@ -517,66 +522,68 @@ split {
 	if (version == "v2.4.1" || version == "v2.4.2" || version == "v2.4.3" || version == "v2.4.4") {
 		// Trinket splits
 		if (settings[vars.trinkets]) {
-			if (current.collect[0] == 1 && old.collect[0] == 0) {
-				// Trinket - It's a Secret to Nobody
-				return settings[vars.trinketSecretToNobody];
-			} else if (current.collect[1] == 1 && old.collect[1] == 0) {
-				// Trinket - Trench Warfare
-				return settings[vars.trinketTrenchWarfare];
-			} else if (current.collect[9] == 1 && old.collect[9] == 0) {
-				// Trinket - Young Man, It's Worth the Challenge
-				return settings[vars.trinketWorthTheChallenge];
-			} else if (current.collect[14] == 1 && old.collect[14] == 0) {
-				// Trinket - Lab Maze
-				return settings[vars.trinketLabMaze];
-			} else if (current.collect[10] == 1 && old.collect[10] == 0) {
-				// Trinket - Lab Maze
-				return settings[vars.trinketTantalizing];
-			} else if (current.collect[11] == 1 && old.collect[11] == 0) {
-				// Trinket - Purest Unobtainium
-				return settings[vars.trinketUnobtainium];
-			} else if (current.collect[18] == 1 && old.collect[18] == 0) {
-				// Trinket - Victoria
-				return settings[vars.trinketVictoria];
-			} else if (current.collect[7] == 1 && old.collect[7] == 0) {
-				// Trinket - Tower 1
-				return settings[vars.trinketTower1];
-			} else if (current.collect[8] == 1 && old.collect[8] == 0) {
-				// Trinket - Lab Maze
-				return settings[vars.trinketTower2];
-			} else if (current.collect[17] == 1 && old.collect[17] == 0) {
-				// Trinket - Elephant
-				return settings[vars.trinketElephant];
-			} else if (current.collect[2] == 1 && old.collect[2] == 0) {
-				// Trinket - One Way Room
-				return settings[vars.trinketOneWayRoom];
-			} else if (current.collect[3] == 1 && old.collect[3] == 0) {
-				// Trinket - You Just Keep Coming Back
-				return settings[vars.trinketKeepComingBack];
-			} else if (current.collect[4] == 1 && old.collect[4] == 0) {
-				// Trinket - Clarion Call
-				return settings[vars.trinketClarionCall];
-			} else if (current.collect[5] == 1 && old.collect[5] == 0) {
-				// Trinket - Doing Things the Hard Way
-				return settings[vars.trinketDTTHW];
-			} else if (current.collect[6] == 1 && old.collect[6] == 0) {
-				// Trinket - Prize for the Reckless
-				return settings[vars.trinketPrizeForTheReckless];
-			} else if (current.collect[15] == 1 && old.collect[15] == 0) {
-				// Trinket - Cave 1
-				return settings[vars.trinketCave1];
-			} else if (current.collect[16] == 1 && old.collect[16] == 0) {
-				// Trinket - Cave 2
-				return settings[vars.trinketCave2];
-			} else if (current.collect[13] == 1 && old.collect[13] == 0) {
-				// Trinket - Cave 3
-				return settings[vars.trinketCave3];
-			} else if (current.collect[12] == 1 && old.collect[12] == 0) {
-				// Trinket - Edge Games
-				return settings[vars.trinketEdgeGames];
-			} else if (current.collect[19] == 1 && old.collect[19] == 0) {
-				// Trinket - V
-				return settings[vars.trinketV];
+			if (!settings[vars.disableTimeTrialTrinkets] || settings[vars.disableTimeTrialTrinkets] && !vars.isInTimeTrial) {
+				if (current.collect[0] == 1 && old.collect[0] == 0) {
+					// Trinket - It's a Secret to Nobody
+					return settings[vars.trinketSecretToNobody];
+				} else if (current.collect[1] == 1 && old.collect[1] == 0) {
+					// Trinket - Trench Warfare
+					return settings[vars.trinketTrenchWarfare];
+				} else if (current.collect[9] == 1 && old.collect[9] == 0) {
+					// Trinket - Young Man, It's Worth the Challenge
+					return settings[vars.trinketWorthTheChallenge];
+				} else if (current.collect[14] == 1 && old.collect[14] == 0) {
+					// Trinket - Lab Maze
+					return settings[vars.trinketLabMaze];
+				} else if (current.collect[10] == 1 && old.collect[10] == 0) {
+					// Trinket - Lab Maze
+					return settings[vars.trinketTantalizing];
+				} else if (current.collect[11] == 1 && old.collect[11] == 0) {
+					// Trinket - Purest Unobtainium
+					return settings[vars.trinketUnobtainium];
+				} else if (current.collect[18] == 1 && old.collect[18] == 0) {
+					// Trinket - Victoria
+					return settings[vars.trinketVictoria];
+				} else if (current.collect[7] == 1 && old.collect[7] == 0) {
+					// Trinket - Tower 1
+					return settings[vars.trinketTower1];
+				} else if (current.collect[8] == 1 && old.collect[8] == 0) {
+					// Trinket - Lab Maze
+					return settings[vars.trinketTower2];
+				} else if (current.collect[17] == 1 && old.collect[17] == 0) {
+					// Trinket - Elephant
+					return settings[vars.trinketElephant];
+				} else if (current.collect[2] == 1 && old.collect[2] == 0) {
+					// Trinket - One Way Room
+					return settings[vars.trinketOneWayRoom];
+				} else if (current.collect[3] == 1 && old.collect[3] == 0) {
+					// Trinket - You Just Keep Coming Back
+					return settings[vars.trinketKeepComingBack];
+				} else if (current.collect[4] == 1 && old.collect[4] == 0) {
+					// Trinket - Clarion Call
+					return settings[vars.trinketClarionCall];
+				} else if (current.collect[5] == 1 && old.collect[5] == 0) {
+					// Trinket - Doing Things the Hard Way
+					return settings[vars.trinketDTTHW];
+				} else if (current.collect[6] == 1 && old.collect[6] == 0) {
+					// Trinket - Prize for the Reckless
+					return settings[vars.trinketPrizeForTheReckless];
+				} else if (current.collect[15] == 1 && old.collect[15] == 0) {
+					// Trinket - Cave 1
+					return settings[vars.trinketCave1];
+				} else if (current.collect[16] == 1 && old.collect[16] == 0) {
+					// Trinket - Cave 2
+					return settings[vars.trinketCave2];
+				} else if (current.collect[13] == 1 && old.collect[13] == 0) {
+					// Trinket - Cave 3
+					return settings[vars.trinketCave3];
+				} else if (current.collect[12] == 1 && old.collect[12] == 0) {
+					// Trinket - Edge Games
+					return settings[vars.trinketEdgeGames];
+				} else if (current.collect[19] == 1 && old.collect[19] == 0) {
+					// Trinket - V
+					return settings[vars.trinketV];
+				}
 			}
 		}
 
@@ -663,6 +670,7 @@ split {
 			} else if (current.gamestate >= 82 && current.gamestate <= 84) {
 				if (old.gamestate < 82 || old.gamestate > 84) {
 					// Split on completing time trials
+					vars.isInTimeTrial = false;
 					return settings[vars.ils];
 				}
 			} else if (current.gamestate == 4050 && current.teleport_to_x == 8 && current.teleport_to_y == 11) {
@@ -849,6 +857,7 @@ reset {
 		if (current.menustate != 0 && current.menustate != 2 && current.menustate != 3 && (current.menustate != 1 || !current.ingame_titlemode)) {
 			if (old.menustate == 0 || old.menustate == 2 || old.menustate == 3 || (old.menustate == 1 && old.ingame_titlemode)) {
 				// Reset on exiting to menu
+				vars.isInTimeTrial = false;
 				return settings[vars.menuReset] || settings[vars.ils];
 			}
 		}

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -27,6 +27,7 @@ state("VVVVVV", "v2.4.4") {
 	int teleport_to_y : "VVVVVV.exe", 0x410C04; // game.teleport_to_y
 	byte100 collect : "VVVVVV.exe", 0x221790; // obj.collect (obj = entityclass)
 	bool noDeathMode : "VVVVVV.exe", 0x410CDC; // game.nodeathmode
+	int swnRank : "VVVVVV.exe", 0x410CC4; // game.swnrank
 
 	// Time trial variables for calculating V rank
 	// Why not just read the timetrialrank variable? In short, because of race conditions.
@@ -232,6 +233,7 @@ startup {
 	vars.disableTimeTrialTrinkets = "Disable splitting on trinkets when in a Time Trial (v2.4.1+)";
 	vars.requireVRank = "Only split on completing time trials when V Rank is achieved (v2.4.4+)";
 	vars.motu = "In NDM, split on attaining MotU instead of Game Complete (v2.4.4+)";
+	vars.sgrav = "Split on reaching 1 minute in the Super Gravitron (v2.4.4+)";
 
 	vars.trinkets = "Split on collecting trinkets";
 	vars.trinketSecretToNobody = "Split on collecting the \"It's a Secret to Nobody\" trinket";
@@ -316,6 +318,7 @@ startup {
 	settings.Add(vars.disableTimeTrialTrinkets, false);
 	settings.Add(vars.requireVRank, false);
 	settings.Add(vars.motu, false);
+	settings.Add(vars.sgrav, false);
 
 	settings.CurrentDefaultParent = vars.hundredpercentParent;
 	settings.Add(vars.labTelejump, false);
@@ -767,6 +770,10 @@ split {
 				// Use this variable to disable splitting on trinkets in time trials, if the option to do so has been selected
 				vars.isInTimeTrial = true;
 			}
+		}
+
+		if (current.swnRank == 6 && old.swnRank != 6) { // rank 6 is 60 seconds
+			return settings[vars.sgrav];
 		}
 
 		return false;

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -22,7 +22,7 @@ state("VVVVVV", "v2.4.4") {
 	bool finalStretch : "VVVVVV.exe", 0x4136C9; // map.finalstretch
 	int gamestate : "VVVVVV.exe", 0x410B50; // game.state
 	string255 firstTextLineSmall : "VVVVVV.exe", 0x233980, 0x0; // script.txt.Myfirst_ (script = scriptclass)
-	string255 firstTextLineLarge : "VVVVVV.exe", 0x233980, 0x0, 0x0; // script.text.Myfirst_
+	string255 firstTextLineLarge : "VVVVVV.exe", 0x233980, 0x0, 0x0; // script.txt.Myfirst_
 	int teleport_to_x : "VVVVVV.exe", 0x410C00; // game.teleport_to_x
 	int teleport_to_y : "VVVVVV.exe", 0x410C04; // game.teleport_to_y
 	byte100 collect : "VVVVVV.exe", 0x221790; // obj.collect (obj = entityclass)

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -1,6 +1,6 @@
 // Planned new split options to implement:
 //		1. Split on the Comms Relay cutscene (useful for Text Storage No OoB) - DONE
-//		2. Disable splitting on trinkets when in time trial (useful for All Achievements) - TESTING
+//		2. Disable splitting on trinkets when in time trial (useful for All Achievements) - DONE
 //		3. Only split on time trials when V Rank achieved (useful for All Achievements)
 
 state("VVVVVV", "unknown") {
@@ -455,6 +455,7 @@ start {
 			} else if (current.gotomode >= 3 && current.gotomode <= 8) {
 				// Time trials
 				// Time trial starting behaviour is done elsewhere
+				vars.isInTimeTrial = true;
 				return false;
 			} else if (current.gotomode >= 9 && current.gotomode <= 10) {
 				// No death mode (with or without cutscenes)
@@ -680,9 +681,14 @@ split {
 				// Split on teleporting to the teleporter under Lab
 				return settings[vars.labTelejump];
 			} else if (current.gamestate == 31) {
-				if (old.gamestate != 31) {
+				if (old.gamestate != 31) { // Comms Relay gamestate
 					// Split on activating the cutscene in Comms Relay
 					return settings[vars.commsRelay];
+				}
+			} else if (current.gamestate == 81) { // quit to menu gamestate
+				if (old.gamestate != 81) {
+					// whether or not we were previously in a time trial, we definitely aren't now!
+					vars.isInTimeTrial = false;
 				}
 			}
 		}
@@ -696,6 +702,14 @@ split {
 			if (old.firstTextLineSmall != "Hello!" && old.firstTextLineLarge != "Hello!") {
 				// Split on "Hello!" appearing
 				return settings[vars.hello];
+			}
+		}
+
+		if (current.timetrialcountdown != old.timetrialcountdown) {
+			if (current.timetrialcountdown <= 30 && old.timetrialcountdown > 30) {
+				// Test if the time trial countdown has ended
+				// Use this variable to disable splitting on trinkets in time trials, if the option to do so has been selected
+				vars.isInTimeTrial = true;
 			}
 		}
 

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -1,7 +1,7 @@
 // Planned new split options to implement:
 //		1. Split on the Comms Relay cutscene (useful for Text Storage No OoB) - DONE
 //		2. Disable splitting on trinkets when in time trial (useful for All Achievements) - DONE
-//		3. Only split on time trials when V Rank achieved (useful for All Achievements) - IN PROGRESS
+//		3. Only split on time trials when V Rank achieved (useful for All Achievements) - TESTING
 
 state("VVVVVV", "unknown") {
 	// Default state
@@ -27,6 +27,7 @@ state("VVVVVV", "v2.4.4") {
 	int teleport_to_x : "VVVVVV.exe", 0x410C00;
 	int teleport_to_y : "VVVVVV.exe", 0x410C04;
 	byte100 collect : "VVVVVV.exe", 0x221790;
+	int timeTrialRank : "VVVVVV.exe", 0x410D30;
 	
 	// Variables for resetting
 	int menustate : "VVVVVV.exe", 0x410B5C; // actually called gamestate in source
@@ -306,6 +307,7 @@ startup {
 	settings.Add(vars.allAchievementsParent, false);
 	settings.CurrentDefaultParent = vars.allAchievementsParent;
 	settings.Add(vars.disableTimeTrialTrinkets, false);
+	settings.Add(vars.requireVRank, false);
 
 	settings.CurrentDefaultParent = vars.hundredpercentParent;
 	settings.Add(vars.labTelejump, false);
@@ -496,7 +498,7 @@ start {
 		if (current.timetrialcountdown != old.timetrialcountdown) {
 			if (current.timetrialcountdown <= 30 && old.timetrialcountdown > 30) {
 				// Start when time trial countdown ends
-				vars.isInTimeTrial = true;
+				vars.isInTimeTrial = true; // if you're doing All Achievements, you really shouldn't be starting your run from a time trial, but we'll set the variable here anyway
 				return settings[vars.ils];
 			}
 		}
@@ -678,7 +680,16 @@ split {
 				if (old.gamestate < 82 || old.gamestate > 84) {
 					// Split on completing time trials
 					vars.isInTimeTrial = false;
-					return settings[vars.ils];
+					
+					if (!settings[vars.requireVRank]) {
+						return settings[vars.ils];
+					}
+				} else if (old.gamestate == 82) { // evil check just to make sure timetrialrank has been updated before we try to read its new value. could be inconsistent, might be better to check for gamestate 83 instead
+					print("The time trial rank is " + current.timeTrialRank); // REMOVE ME!!
+					
+					if (current.timeTrialRank >= 3) { // personally, i think this check should be == 3, but the game checks >= 3 to determine whether or not to award V rank, so the same should be done in the autosplitter
+						return settings[vars.ils];
+					}
 				}
 			} else if (current.gamestate == 4050 && current.teleport_to_x == 8 && current.teleport_to_y == 11) {
 				// Split on teleporting to the teleporter under Tower

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -26,6 +26,7 @@ state("VVVVVV", "v2.4.4") {
 	int teleport_to_x : "VVVVVV.exe", 0x410C00; // game.teleport_to_x
 	int teleport_to_y : "VVVVVV.exe", 0x410C04; // game.teleport_to_y
 	byte100 collect : "VVVVVV.exe", 0x221790; // obj.collect (obj = entityclass)
+	bool noDeathMode : "VVVVVV.exe", 0x410CDC; // game.nodeathmode
 
 	// Time trial variables for calculating V rank
 	// Why not just read the timetrialrank variable? In short, because of race conditions.
@@ -230,6 +231,7 @@ startup {
 	vars.allAchievementsParent = "Settings pertaining to All Achievements";
 	vars.disableTimeTrialTrinkets = "Disable splitting on trinkets when in a Time Trial (v2.4.1+)";
 	vars.requireVRank = "Only split on completing time trials when V Rank is achieved (v2.4.4+)";
+	vars.motu = "In NDM, split on attaining MotU instead of Game Complete (v2.4.4+)";
 
 	vars.trinkets = "Split on collecting trinkets";
 	vars.trinketSecretToNobody = "Split on collecting the \"It's a Secret to Nobody\" trinket";
@@ -313,6 +315,7 @@ startup {
 	settings.CurrentDefaultParent = vars.allAchievementsParent;
 	settings.Add(vars.disableTimeTrialTrinkets, false);
 	settings.Add(vars.requireVRank, false);
+	settings.Add(vars.motu, false);
 
 	settings.CurrentDefaultParent = vars.hundredpercentParent;
 	settings.Add(vars.labTelejump, false);
@@ -674,7 +677,7 @@ split {
 						}
 					}
 
-					if (allTrinketsKludge) {
+					if (allTrinketsKludge && (!settings[vars.motu] || settings[vars.motu] && !current.noDeathMode)) {
 						vars.isGameComplete = settings[vars.gameComplete];
 					}
 				}
@@ -738,6 +741,10 @@ split {
 				if (old.gamestate != 81) {
 					// whether or not we were previously in a time trial, we definitely aren't now!
 					vars.isInTimeTrial = false;
+				}
+			} else if (current.gamestate == 3510) { // trophies awarded
+				if (old.gamestate != 3510) {
+					return settings[vars.motu] && current.noDeathMode;
 				}
 			}
 		}

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -539,6 +539,7 @@ split {
 		// the timer. This is so that the gameTime method can be run one more time before the timer stops, in which it will switch over to displaying
 		// the save file's saved time (set in gamestate 3502) instead of the in-game time.
 		if (vars.isGameComplete) {
+			vars.isGameComplete = false;
 			return true;
 		}
 

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -1,5 +1,5 @@
 // Planned new split options to implement:
-//		1. Split on the Comms Relay cutscene (useful for Text Storage No OoB)
+//		1. Split on the Comms Relay cutscene (useful for Text Storage No OoB) - DONE
 //		2. Disable splitting on trinkets when in time trial (useful for All Achievements)
 //		3. Only split on time trials when V Rank achieved (useful for All Achievements)
 
@@ -671,7 +671,7 @@ split {
 			} else if (current.gamestate == 4020 && current.teleport_to_x == 0 && current.teleport_to_y == 0) {
 				// Split on teleporting to the teleporter under Lab
 				return settings[vars.labTelejump];
-			} else if (current.gamastate == 31) {
+			} else if (current.gamestate == 31) {
 				if (old.gamestate != 31) {
 					// Split on activating the cutscene in Comms Relay
 					return settings[vars.commsRelay];

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -455,7 +455,6 @@ start {
 			} else if (current.gotomode >= 3 && current.gotomode <= 8) {
 				// Time trials
 				// Time trial starting behaviour is done elsewhere
-				vars.isInTimeTrial = true;
 				return false;
 			} else if (current.gotomode >= 9 && current.gotomode <= 10) {
 				// No death mode (with or without cutscenes)

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -21,8 +21,8 @@ state("VVVVVV", "v2.4.4") {
 	// Variables for splitting
 	bool finalStretch : "VVVVVV.exe", 0x4136C9; // map.finalstretch
 	int gamestate : "VVVVVV.exe", 0x410B50; // game.state
-	string255 firstTextLineSmall : "VVVVVV.exe", 0x233980, 0x0; // script.txt (script = scriptclass)
-	string255 firstTextLineLarge : "VVVVVV.exe", 0x233980, 0x0, 0x0; // script.text
+	string255 firstTextLineSmall : "VVVVVV.exe", 0x233980, 0x0; // script.txt.Myfirst_ (script = scriptclass)
+	string255 firstTextLineLarge : "VVVVVV.exe", 0x233980, 0x0, 0x0; // script.text.Myfirst_
 	int teleport_to_x : "VVVVVV.exe", 0x410C00; // game.teleport_to_x
 	int teleport_to_y : "VVVVVV.exe", 0x410C04; // game.teleport_to_y
 	byte100 collect : "VVVVVV.exe", 0x221790; // obj.collect (obj = entityclass)

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -1,3 +1,8 @@
+// Planned new split options to implement:
+//		1. Split on the Comms Relay cutscene (useful for Text Storage No OoB)
+//		2. Disable splitting on trinkets when in time trial (useful for All Achievements)
+//		3. Only split on time trials when V Rank achieved (useful for All Achievements)
+
 state("VVVVVV", "unknown") {
 	// Default state
 }

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -1,8 +1,3 @@
-// Planned new split options to implement:
-//		1. Split on the Comms Relay cutscene (useful for Text Storage No OoB) - DONE
-//		2. Disable splitting on trinkets when in time trial (useful for All Achievements) - DONE
-//		3. Only split on time trials when V Rank achieved (useful for All Achievements) - TESTING
-
 state("VVVVVV", "unknown") {
 	// Default state
 }
@@ -27,8 +22,14 @@ state("VVVVVV", "v2.4.4") {
 	int teleport_to_x : "VVVVVV.exe", 0x410C00;
 	int teleport_to_y : "VVVVVV.exe", 0x410C04;
 	byte100 collect : "VVVVVV.exe", 0x221790;
-	int timeTrialRank : "VVVVVV.exe", 0x410D30;
-	
+
+	// Time trial variables for calculating V rank
+	// Why not just read the timetrialrank variable? In short, because of race conditions.
+	// We can't reliably read from any variables which are affected by gamestate 82 while also listening out for gamestate 82.
+	int deathCount : "VVVVVV.exe", 0x410B94;
+	int timeTrialShinyTarget : "VVVVVV.exe", 0x410D1C;
+	int timeTrialPar : "VVVVVV.exe", 0x410D24;
+
 	// Variables for resetting
 	int menustate : "VVVVVV.exe", 0x410B5C; // actually called gamestate in source
 	bool ingame_titlemode : "VVVVVV.exe", 0x411566;
@@ -683,12 +684,30 @@ split {
 					
 					if (!settings[vars.requireVRank]) {
 						return settings[vars.ils];
-					}
-				} else if (old.gamestate == 82) { // evil check just to make sure timetrialrank has been updated before we try to read its new value. could be inconsistent, might be better to check for gamestate 83 instead
-					print("The time trial rank is " + current.timeTrialRank); // REMOVE ME!!
-					
-					if (current.timeTrialRank >= 3) { // personally, i think this check should be == 3, but the game checks >= 3 to determine whether or not to award V rank, so the same should be done in the autosplitter
-						return settings[vars.ils];
+					} else {
+						// We have to calculate whether the player has gotten V rank ourselves here, because there's a chance
+						// that at the time the autosplitter notices gamestate == 82, the game hasn't yet itself processed the
+						// new gamestate and finished calculating the player's rank. Yes, I'm aware this is pretty scuffed.
+						// I won't be happy if this works.
+						bool isUnderParTime = (current.gametimeHours * 3600 + current.gametimeMinutes * 60 + current.gametimeSeconds <= current.timeTrialPar);
+						bool isDeathless = (current.deathCount == 0);
+						
+						int collectedTrinkets = 0;
+
+						for (int i = 0; i < 20; i++) {
+							if (current.collect[i] != 0) {
+								collectedTrinkets++;
+							}
+						}
+
+						bool hasEnoughTrinkets = (collectedTrinkets >= current.timeTrialShinyTarget);
+
+						if (isUnderParTime && isDeathless && hasEnoughTrinkets) {
+							return settings[vars.ils];
+						}
+
+						// After testing, I can confirm this works (splits on V rank and doesn't on anything else), and it splits at the proper time.
+						// (My first idea split a frame late.) As predicted, I'm not happy about this; it's even more scuffed than the 100% check on game complete.
 					}
 				}
 			} else if (current.gamestate == 4050 && current.teleport_to_x == 8 && current.teleport_to_y == 11) {

--- a/LiveSplit.VVVVVV.asl
+++ b/LiveSplit.VVVVVV.asl
@@ -224,8 +224,8 @@ startup {
 	vars.towerTelejump = "Split on teleporting to the teleporter under Tower";
 
 	vars.allAchievementsParent = "Settings pertaining to All Achievements";
-	vars.disableTimeTrialTrinkets = "Disable splitting on trinkets when in a time trial (v2.4.1+ currently)";
-	vars.requireVRank = "Only split on completing time trials when V Rank is achieved (v2.4.4+ currently)";
+	vars.disableTimeTrialTrinkets = "Disable splitting on trinkets when in a Time Trial (v2.4.1+)";
+	vars.requireVRank = "Only split on completing time trials when V Rank is achieved (v2.4.4+)";
 
 	vars.trinkets = "Split on collecting trinkets";
 	vars.trinketSecretToNobody = "Split on collecting the \"It's a Secret to Nobody\" trinket";
@@ -255,7 +255,7 @@ startup {
 	vars.dis = "Split on talking to Victoria (for DIS)";
 	vars.finalStretch = "Split on Final Level terminal";
 	vars.hello = "Split on \"Hello!\" (for Text Storage and Credits Warp)";
-	vars.commsRelay = "Split on activating the cutscene in Comms Relay (v2.4.1+ currently)";
+	vars.commsRelay = "Split on activating the cutscene in \"Comms Relay\" (v2.4.1+)";
 
 	settings.Add(vars.startresetParent, true);
 	settings.CurrentDefaultParent = vars.startresetParent;


### PR DESCRIPTION
I added a few new options for splitting that I've been wanting for a bit, and also fixed a longstanding bug within the autosplitter.

### New split options

#### Split on Comms Relay cutscene

Located under miscellaneous settings. Simply listens for gamestate 31, and then splits if this option is enabled. Admittedly, pretty much only useful for Text Storage No OoB, and not much else. That said, I'd still get use out of this option on the rare occasion where I run that. Currently, this option only works for v2.4.1 and up.

#### Disable splitting on trinkets when doing a Time Trial

Located under "Settings pertaining to All Achievements", which itself is located under "Settings pertaining to 100% categories". Uses an internal variable to keep track of whether the player is in a time trial or not, and disables trinket splits if they are, and if this option is selected. As might be ascertained, useful for All Achievements. This setting also currently only works for v2.4.1 and up.

#### Only split on completing Time Trials upon getting V Rank

Located under "Settings pertaining to All Achievements". When the gamestate is 82, if this option is selected, the autosplitter determines whether or not the player has gotten a V Rank, and splits if that's the case. The autosplitter determines rank by reading death count, the Time Trial's par time, and the Time Trial's trinket minimum, before running the same checks as the game. At first I tried doing this by simply reading the time trial rank variable from the game, but that led to inconsistent results, as that variable is modified when the game handles gamestate 82. I needed to perform the check without using variables which are modified by gamestate 82, thus this workaround. As this setting required reading in extra variables to the state, this setting only works in v2.4.4.

### Bugfix

#### Livesplit now shows correct time on Game Complete screen

For at least as long as I've been running this game, the autosplitter has had a tendency to stop its timer a frame (or rarely 2) after the time shown on the Game Complete screen. The reason for this discrepancy was because the game saves the in-game time to the player's save file on gamestate 3502, but the autosplitter was listening for gamestate 3503. Interestingly, upon examining the code, it appears that the game does not actually stop the in-game timer; it only saves the time to the player's save file, and then displays the save file time ont he Game Complete screen. Thus, the solution to solve this bug was to, upon gamestate 3503 being reached, have the gameTime method read from the save file's time instead of the in-game time, and also have the split method wait an extra cycle before splitting, as gameTime does not get called after the timer stops.

A potential complication of this, which has not yet been accounted for (and thus I can change before this gets considered for merging if desired), is that, in real-time categories in which the Game Complete screen is reached (so basically just All Achievements), I believe it's possible that the autosplitter could split an extra frame late. However, I have not currently tested to see if this is actually the case.

Finally, as this bugfix required reading in the game's saved time, which was not used before, this fix currently only applies to v2.4.4.

One last thing: as a lot of these changes involved adding more variables to the state, which is more variable locations that'll need updated every game update, I've added more documentation in the autosplitter code to where everything can be found.